### PR TITLE
move FritzProfileSwitch to toplevel

### DIFF
--- a/fritz_switch_profiles/__init__.py
+++ b/fritz_switch_profiles/__init__.py
@@ -2,3 +2,5 @@ import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 name = "fritz_switch_profiles"
+
+from .fritz_switch_profiles import FritzProfileSwitch

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fritz-switch-profiles",
-    version="0.0.1",
+    version="0.0.2",
     author="Kevin Eifinger",
     author_email="k.eifinger@googlemail.com",
     description="A (Python) script to remotely set device profiles of an AVM Fritz!Box",


### PR DESCRIPTION
The example I have given did not work due to the packaging.
The correct example would have been:
```python
from fritz_switch_profiles.fritz_switch_profiles import FritzProfileSwitch
```

As I didn't find that very intuitive I imported FritzProfileSwitch to the toplevel, as they do it on [slackclient](https://github.com/slackapi/python-slackclient/blob/master/slackclient/__init__.py)

Grüße aus Mainz