### PR TITLE
Support for special characters like umlauts

### DIFF
--- a/fritz_switch_profiles/fritz_switch_profiles.py
+++ b/fritz_switch_profiles/fritz_switch_profiles.py
@@ -52,7 +52,7 @@ class FritzProfileSwitch:
         data = {'xhr': 1, 'sid': self.sid, 'cancel': '', 'oldpage': '/internet/kids_userlist.lua'}
         url = self.url + '/data.lua'
         r = requests.post(url, data=data, allow_redirects=True)
-        html = lxml.html.fromstring(r.content)
+        html = lxml.html.fromstring(r.text)
         for row in html.xpath('//table[@id="uiDevices"]/tr'):
             td = row.xpath('td')
             if (not td) or (len(td) != 5):
@@ -127,7 +127,7 @@ class FritzProfileSwitch:
         data = {'xhr': 1, 'sid': self.sid, 'no_sidrenew': '', 'page': 'kidPro'}
         url = self.url + '/data.lua'
         r = requests.post(url, data=data, allow_redirects=True)
-        html = lxml.html.fromstring(r.content)
+        html = lxml.html.fromstring(r.text)
         self.profiles = []
         for row in html.xpath('//table[@id="uiProfileList"]/tr'):
             profile_name = row.xpath('td[@class="name"]/span/text()')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fritz-switch-profiles",
-    version="0.0.2",
+    version="1.0.0",
     author="Kevin Eifinger",
     author_email="k.eifinger@googlemail.com",
     description="A (Python) script to remotely set device profiles of an AVM Fritz!Box",


### PR DESCRIPTION
The response for the devices and profiles was parsed into the wrong encoding.
This adds support for German Umlauts(ä,ö,ü) and theoretically for everything in the UTF-8 encoding.

Found the information here:
https://stackoverflow.com/questions/29057188/lxml-not-parsing-unicode-properly-for-html